### PR TITLE
Break up Dockerfile.

### DIFF
--- a/interop/Dockerfile
+++ b/interop/Dockerfile
@@ -3,14 +3,30 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.18
 SHELL ["/bin/bash", "-c"]
 
 # Install yq, kubectl, oc tools.
-RUN yum install --assumeyes -d1 python3-pip  httpd-tools && \
-    pip3 install --upgrade setuptools && \
-    pip3 install yq && \
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+RUN yum install --assumeyes -d1 python3-pip  httpd-tools
+RUN pip3 install --upgrade setuptools
+RUN pip3 install yq
+    
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
-    mv ./kubectl /usr/local/bin && \
-    curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.12/openshift-client-linux.tar.gz | tar xvzf - -C /usr/local/bin/ oc && \
-    chmod ug+x /usr/local/bin/oc
+    mv ./kubectl /usr/local/bin
+
+# Download the oc.tar.gz file
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.12/openshift-client-linux.tar.gz -o /tmp/oc.tar.gz
+
+# Extract the oc binary from oc.tar.gz to /usr/local/bin/
+RUN tar xvzf /tmp/oc.tar.gz -C /usr/local/bin/
+
+# Make the oc binary executable
+RUN chmod +x /usr/local/bin/oc
+
+# Clean up the temporary file
+RUN rm /tmp/oc.tar.gz
+
+# Copy the devspaces-interop-tests repo into /tmp/devspaces folder
+RUN mkdir /tmp/devspaces
+WORKDIR /tmp/devspaces
+COPY . .
 
 # Set required permissions for OpenShift usage
 RUN mkdir -p /.config && \

--- a/scripts/execute-test-harness.sh
+++ b/scripts/execute-test-harness.sh
@@ -36,7 +36,6 @@ cat kubeconfig.template.yml |
     sed -e "s#__OPENSHIFT_API_TOKEN__#${OPENSHIFT_API_TOKEN}#g" |
     cat >${TMP_KUBECONFIG_YML}
 
-cat ${TMP_KUBECONFIG_YML}
 
 oc delete configmap -n ${OPERATORS_NAMESPACE} ds-testsuite-kubeconfig || true
 
@@ -57,7 +56,6 @@ cat test-harness.pod.template.yml |
     sed -e "s#__DEV_SPACES_VERSION__#${DS_VERSION}#g" |
     cat >${TMP_POD_YML}
 
-cat ${TMP_POD_YML}
 
 # start the test
 echo "[INFO] Creating pod 'ds-testsuite-${ID}' in namespace '${OPERATORS_NAMESPACE}'"


### PR DESCRIPTION
Made some simple changes to Dockerfile to pass build in OpenShift CI.

Removed two cat commands for security purposes from the execute script.
- In OpenShift CI everything is public so we cannot cat files that hold things like user tokens.