### PR TITLE
Fix up name of 'lombok' devfile

### DIFF
--- a/tests/workspace_tests.go
+++ b/tests/workspace_tests.go
@@ -66,7 +66,7 @@ var _ = Describe("[WORKSPACES]", func() {
 })
 
 func ObtainJavaDevFileUrl(cheCluster *orgv2.CheCluster) string {
-	return cheCluster.Status.DevfileRegistryURL + "/devfiles/java11-maven-lombok__lombok-project-sample/devworkspace-che-code-latest.yaml"
+	return cheCluster.Status.DevfileRegistryURL + "/devfiles/java-maven-lombok__lombok-project-sample/devworkspace-che-code-latest.yaml"
 }
 
 func GetDevWorkspaceYaml(dwYamlFile []byte) *v1alpha2.DevWorkspace {


### PR DESCRIPTION
* Fix up the name of `lombok` devfile, which is used in the test 'Obtain and patch Devfile from DevFile Registry'

https://issues.redhat.com/browse/CRW-5726