### PR TITLE
Fix: stop using mirror.centos.org repo

### DIFF
--- a/interop/Dockerfile
+++ b/interop/Dockerfile
@@ -1,6 +1,11 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18
+FROM registry.ci.openshift.org/openshift/release:golang-1.19
 
 SHELL ["/bin/bash", "-c"]
+
+# Temporary workaround since mirror.centos.org is down and can be replaced with vault.centos.org
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
 # Install yq, kubectl, oc tools.
 RUN yum install --assumeyes -d1 python3-pip  httpd-tools


### PR DESCRIPTION
* Replaces usage of http://mirrorlist.centos.org/ repo with http://vault.centos.org/ as http://mirrorlist.centos.org/ is now down that Centos 7 is EOL as of July 1st 2024.

* Without this fix, the Dockerfile fails to build with the error:
```
Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was
14: curl#6 - "Could not resolve host: mirrorlist.centos.org; Unknown error" 
```
* This is more of a temporary work-around as the issue probably should be fixed in the image being used:
`registry.ci.openshift.org/openshift/release:golang-1.19`